### PR TITLE
Prevent infinite loop when matrix rows are greater than columns

### DIFF
--- a/HungarianAlgorithm/HungarianAlgorithm.cs
+++ b/HungarianAlgorithm/HungarianAlgorithm.cs
@@ -82,6 +82,10 @@ public static class HungarianAlgorithm
                     agentsTasks[i] = j;
                     break;
                 }
+                else
+                {
+                    agentsTasks[i] = -1;
+                }
             }
         }
 
@@ -113,7 +117,7 @@ public static class HungarianAlgorithm
                 colsCoveredCount++;
         }
 
-        if (colsCoveredCount == h)
+        if (colsCoveredCount == Math.Min(w, h))
             return -1;
 
         return 2;


### PR DESCRIPTION
- Problem was reported that the program will enter into infinite loop when row > col. This is because the number of valid matches can never reach the row number in this case.
- Use column number instead when row > col. Unmatched assignees in this case will be marked as index -1.