### PR TITLE
Fix non-optimal issue by keeping matrix column greater than row

### DIFF
--- a/HungarianAlgorithm/HungarianAlgorithm.cs
+++ b/HungarianAlgorithm/HungarianAlgorithm.cs
@@ -20,6 +20,24 @@ public static class HungarianAlgorithm
 
         var h = costs.GetLength(0);
         var w = costs.GetLength(1);
+        bool rowsGreaterThanCols = h > w;
+        if (rowsGreaterThanCols)
+        {
+            // make sure cost matrix has number of rows greater than columns
+            var row = w;
+            var col = h;
+            var transposeCosts = new int [row, col];
+            for (var i = 0; i < row; i++)
+            {
+                for (var j = 0; j < col;j++)
+                {
+                    transposeCosts[i, j] = costs[j, i];
+                }
+            }
+            costs = transposeCosts;
+            h = row;
+            w = col;
+        }
 
         for (var i = 0; i < h; i++)
         {
@@ -87,6 +105,21 @@ public static class HungarianAlgorithm
                     agentsTasks[i] = -1;
                 }
             }
+        }
+
+        if (rowsGreaterThanCols)
+        {
+            var agentsTasksTranspose = new int[w];
+            for (var i = 0; i < w; i++)
+            {
+                agentsTasksTranspose[i] = -1;
+            }
+            
+            for (var j = 0; j < h; j++)
+            {
+                agentsTasksTranspose[agentsTasks[j]] = j;
+            }
+            agentsTasks = agentsTasksTranspose;
         }
 
         return agentsTasks;


### PR DESCRIPTION
- The algorithm is unable to get correct result if row > col by its logic.
- The reason (from my shallow analysis) is when rows greater than columns, the substraction for each row will lead to "for each row there is always a zero". Therefore, multiple matches are possible but it is not yet correct.
- I should look in detail in the wikipedia page of Hungarian algorithm to see if there is better fix. Here I flip the matrix if row > col and later on reformulate the matrix with -1.
- Sorry to introduce a bug!
- Test with int[,] {{3,4}, {1,1}, {2,5}}, and compare the result before and after this!
- Will keep you updated.